### PR TITLE
Fix for Play Framework Less.js integration

### DIFF
--- a/mixins/grids.less
+++ b/mixins/grids.less
@@ -3,6 +3,9 @@
 // ==============================================
 
 // You shouldn't need to touch this! Internal use only.
+@column-width: 0;
+@total-columns: 0;
+@gutter-width:0;
 @grid-width: (@column-width*@total-columns) + (@gutter-width*(@total-columns - 1));
 
 .column-wrapper() {


### PR DESCRIPTION
I had this file compilation failing using Play Framework due to the missing definition of column-width, gutter-width and total-columns. 

![Screen Shot 2013-02-25 at 11 37 23](https://f.cloud.github.com/assets/415593/191620/c9b21c74-7f3f-11e2-8724-ebdaecc53d3f.png)

I think it's because Play uses an old version of Less.js (<= 1.3.1, but not really sure if there is any other validity check in the framework itself that fails).

I found that adding a default value of 0 to all of these works just fine.
